### PR TITLE
BUG: Remove babel-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,8 @@
   "devDependencies": {
     "async": "^2.0.1",
     "ava": "^0.19.1",
-    "babel-core": "^6.14.0",
-    "babel-loader": "^6.2.5",
-    "babel-preset-es2015": "^6.14.0",
+    "babel-core": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
     "browserify": "^14.3.0",
     "file-api": "^0.10.4",
     "fs": "0.0.1-security",


### PR DESCRIPTION
Left over from previous webpack explorations. Can cause dependency resolution
issues like:

  $ npm install
  [...]
  └── UNMET PEER DEPENDENCY webpack@1 || 2 || ^2.1.0-beta || ^2.2.0-rc

  npm WARN babel-loader@6.4.1 requires a peer of webpack@1 || 2 || ^2.1.0-beta
  || ^2.2.0-rc but none was installed.

Also update babel-core and babel es2015 preset packages.