### PR TITLE
ci(deploy): set the GIT_PUBLISH_URL in a different way

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -39,7 +39,6 @@ deployment:
     commands:
       - git config --global user.name "Circle CI"
       - git config --global user.email "robot@itk.org"
-      - export GIT_PUBLISH_URL=https://${GH_TOKEN}@github.com/InsightSoftwareConsortium/ITKBridgeJavaScript.git
       - npm run doc:publish
 
   hub:


### PR DESCRIPTION
Attempt to address "{ ProcessError: ERROR: The key you are authenticating with has been marked as
read only."