### PR TITLE
feat(build): uglify generated web workers

### DIFF
--- a/build.js
+++ b/build.js
@@ -128,7 +128,9 @@ const browserifyBuild = ramda.curry(function (outputDir, es6File, callback) {
   let basename = path.basename(es6File)
   let output = path.join(outputDir, basename)
   console.log('Converting ' + basename + ' ...')
-  browserify(es6File)
+  const bundler = browserify(es6File)
+  bundler.transform({global: true}, 'uglifyify')
+  bundler
     .transform('babelify', {presets: ['es2015']})
     .bundle()
     .pipe(fs.createWriteStream(output))

--- a/package.json
+++ b/package.json
@@ -8,13 +8,11 @@
     "test": "test"
   },
   "scripts": {
-    "doc"           : "kw-doc -c ./doc/config.js",
-    "doc:www"       : "kw-doc -c ./doc/config.js -s",
-    "doc:publish"   : "kw-doc -c ./doc/config.js -mp",
-
-    "commit"        : "git cz",
+    "doc": "kw-doc -c ./doc/config.js",
+    "doc:www": "kw-doc -c ./doc/config.js -s",
+    "doc:publish": "kw-doc -c ./doc/config.js -mp",
+    "commit": "git cz",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-
     "build": "node ./build.js",
     "test": "./build/dockcross bash -c \"cd build && ctest -V\" && standard \"src/*.js\" \"test/**/*.js\" && ava \"test/*.js\" && NODE_PATH=$PWD/dist browserify test/Browser/*.js | tape-run --render=\"tap-spec\" --static \"dist/\" --browser firefox"
   },
@@ -41,30 +39,30 @@
   },
   "homepage": "https://github.com/InsightSoftwareConsortium/ITKBridgeJavaScript#readme",
   "devDependencies": {
-    "kw-doc": "1.0.20",
-    "commitizen": "2.9.6",
-    "cz-conventional-changelog": "2.0.0",
-    "semantic-release": "6.3.6",
-    "condition-circle": "1.5.0",
-
     "async": "^2.0.1",
     "ava": "^0.19.1",
     "babel-core": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babelify": "^7.3.0",
     "browserify": "^14.3.0",
+    "commitizen": "2.9.6",
+    "condition-circle": "1.5.0",
+    "cz-conventional-changelog": "2.0.0",
     "file-api": "^0.10.4",
     "fs": "0.0.1-security",
     "fs-extra": "^0.30.0",
     "glob": "^7.0.6",
     "json-loader": "^0.5.4",
+    "kw-doc": "1.0.20",
     "promise-file-reader": "^0.3.1",
     "promise-worker-transferable": "^1.0.4",
     "ramda": "^0.23.0",
+    "semantic-release": "6.3.6",
     "standard": "^8.6.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.6.3",
-    "tape-run": "^3.0.0"
+    "tape-run": "^3.0.0",
+    "uglifyify": "^3.0.4"
   },
   "dependencies": {
     "mime-types": "^2.1.15",


### PR DESCRIPTION
Since these are shipped with browser-based code, they should be small.

Addresses #11