### PR TITLE
feat(config): make the location of the ImageIOs and web workers confi…

### DIFF
--- a/config/browser-test.json
+++ b/config/browser-test.json
@@ -1,0 +1,6 @@
+{
+  'itk': {
+    imageIOsPath: '/itkImageIOs',
+    webWorkersPath: '/itkWebWorkers'
+  }
+}

--- a/config/default.js
+++ b/config/default.js
@@ -1,0 +1,9 @@
+const path = require('path')
+let config = {
+  'itk': {
+    imageIOsPath: path.resolve(__dirname, '..', 'dist', 'itkImageIOs'),
+    webWorkersPath: path.resolve(__dirname, '..', 'dist', 'itkWebWorkers')
+  }
+}
+
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -25,6 +25,16 @@
     "type": "git",
     "url": "git+https://github.com/InsightSoftwareConsortium/ITKBridgeJavaScript.git"
   },
+  "browserify": {
+    "transform": [
+      "aliasify"
+    ]
+  },
+  "aliasify": {
+    "aliases": {
+      "config": "./config/browser-test.json"
+    }
+  },
   "keywords": [
     "itk",
     "imaging",
@@ -39,6 +49,7 @@
   },
   "homepage": "https://github.com/InsightSoftwareConsortium/ITKBridgeJavaScript#readme",
   "devDependencies": {
+    "aliasify": "^2.1.0",
     "async": "^2.0.1",
     "ava": "^0.19.1",
     "babel-core": "^6.24.1",
@@ -63,6 +74,7 @@
     "uglifyify": "^3.0.4"
   },
   "dependencies": {
+    "config": "^1.26.1",
     "mime-types": "^2.1.15",
     "promise-file-reader": "^0.3.1",
     "promise-worker-transferable": "^1.0.4"

--- a/src/WebWorkers/ImageIOWorker.js
+++ b/src/WebWorkers/ImageIOWorker.js
@@ -8,9 +8,6 @@ const getFileExtension = require('../itkgetFileExtension.js')
 const extensionToIO = require('../itkExtensionToIO.js')
 const readImageEmscriptenFSFile = require('../itkreadImageEmscriptenFSFile.js')
 
-// todo: How to make this configurable?
-const config = require('../itkConfig.js')
-
 // To cache loaded io modules
 let ioToModule = {}
 
@@ -19,6 +16,7 @@ let ioToModule = {}
  *    name: fileNameString
  *    type: mimeTypeString
  *    buffer: fileContentsArrayBuffer
+ *    config: itkConfig object
  **/
 registerPromiseWorker(function (input, withTransferList) {
   const extension = getFileExtension(input.name)
@@ -40,7 +38,7 @@ registerPromiseWorker(function (input, withTransferList) {
   if (io in ioToModule) {
     ioModule = ioToModule[io]
   } else {
-    const modulePath = config.imageIOsPath + '/' + io + '.js'
+    const modulePath = input.config.imageIOsPath + '/' + io + '.js'
     importScripts(modulePath)
     ioToModule[io] = Module
     ioModule = Module

--- a/src/itkConfig.js
+++ b/src/itkConfig.js
@@ -1,6 +1,18 @@
-const config = {
+const config = require('config')
+
+let itkConfig = {
   imageIOsPath: '/itkImageIOs',
   webWorkersPath: '/itkWebWorkers'
 }
 
-module.exports = config
+if (typeof config.has === 'function') {
+  if (config.has('itk.imageIOsPath')) {
+    itkConfig['imageIOsPath'] = config.get('itk.imageIOsPath')
+  }
+
+  if (config.has('itk.webWorkersPath')) {
+    itkConfig['webWorkersPath'] = config.get('itk.webWorkersPath')
+  }
+}
+
+module.exports = itkConfig

--- a/src/itkreadImageArrayBuffer.js
+++ b/src/itkreadImageArrayBuffer.js
@@ -6,12 +6,15 @@ const worker = new window.Worker(config.webWorkersPath + '/ImageIOWorker.js')
 const promiseWorker = new PromiseWorker(worker)
 
 /**
+ * Read an image from a file ArrayBuffer in the browser.
+ *
  * @param: buffer arrayBuffer that contains the file contents
  * @param: fileName string that contains the file name
  * @param: mimeType optional mime-type string
  */
 const readImageArrayBuffer = (arrayBuffer, fileName, mimeType) => {
-  return promiseWorker.postMessage({ name: fileName, type: mimeType, buffer: arrayBuffer }, [arrayBuffer])
+  return promiseWorker.postMessage({ name: fileName, type: mimeType, buffer: arrayBuffer, config: config },
+    [arrayBuffer])
 }
 
 module.exports = readImageArrayBuffer

--- a/src/itkreadImageBlob.js
+++ b/src/itkreadImageBlob.js
@@ -14,7 +14,8 @@ const promiseWorker = new PromiseWorker(worker)
 const readImageBlob = (blob, fileName, mimeType) => {
   return PromiseFileReader.readAsArrayBuffer(blob)
     .then(arrayBuffer => {
-      return promiseWorker.postMessage({ name: fileName, type: mimeType, buffer: arrayBuffer }, [arrayBuffer])
+      return promiseWorker.postMessage({ name: fileName, type: mimeType, buffer: arrayBuffer, config: config },
+        [arrayBuffer])
     })
 }
 

--- a/src/itkreadImageFile.js
+++ b/src/itkreadImageFile.js
@@ -9,7 +9,8 @@ const promiseWorker = new PromiseWorker(worker)
 const readImageFile = (file) => {
   return PromiseFileReader.readAsArrayBuffer(file)
     .then(arrayBuffer => {
-      return promiseWorker.postMessage({ name: file.name, type: file.type, buffer: arrayBuffer }, [arrayBuffer])
+      return promiseWorker.postMessage({ name: file.name, type: file.type, buffer: arrayBuffer, config: config },
+        [arrayBuffer])
     })
 }
 

--- a/src/itkreadImageLocalFile.js
+++ b/src/itkreadImageLocalFile.js
@@ -10,6 +10,11 @@ const extensionToIO = require('./itkExtensionToIO.js')
 const loadEmscriptenModule = require('./itkloadEmscriptenModule.js')
 const readImageEmscriptenFSFile = require('./itkreadImageEmscriptenFSFile.js')
 
+/**
+ * Read an image from a file on the local filesystem in Node.js.
+ *
+ * @param: filePath path to the file on the local filesystem.
+ */
 const readImageLocalFile = (filePath) => {
   return new Promise(function (resolve, reject) {
     try {

--- a/test/formatsTest.js
+++ b/test/formatsTest.js
@@ -5,8 +5,6 @@ const IntTypes = require(path.resolve(__dirname, '..', 'dist', 'itkIntTypes.js')
 const FloatTypes = require(path.resolve(__dirname, '..', 'dist', 'itkFloatTypes.js'))
 const PixelTypes = require(path.resolve(__dirname, '..', 'dist', 'itkPixelTypes.js'))
 const readImageLocalFile = require(path.resolve(__dirname, '..', 'dist', 'itkreadImageLocalFile.js'))
-const itkConfig = require(path.resolve(__dirname, '..', 'dist', 'itkConfig.js'))
-itkConfig.imageIOsPath = path.resolve(__dirname, '..', 'dist', 'itkImageIOs')
 
 test('Test reading a PNG file', t => {
   const testFilePath = path.resolve(__dirname, '..', 'build', 'ExternalData', 'test', 'Input', 'cthead1.png')

--- a/test/itkloadEmscriptenModuleTest.js
+++ b/test/itkloadEmscriptenModuleTest.js
@@ -3,7 +3,6 @@ import path from 'path'
 
 const loadModule = require(path.resolve(__dirname, '..', 'dist', 'itkloadEmscriptenModule.js'))
 const itkConfig = require(path.resolve(__dirname, '..', 'dist', 'itkConfig.js'))
-itkConfig.imageIOsPath = path.resolve(__dirname, '..', 'dist', 'itkImageIOs')
 
 test('load a module', t => {
   const modulePath = path.join(itkConfig.imageIOsPath, 'itkPNGImageIOJSBinding.js')

--- a/test/itkreadImageLocalFileTest.js
+++ b/test/itkreadImageLocalFileTest.js
@@ -4,8 +4,6 @@ import path from 'path'
 const IntTypes = require(path.resolve(__dirname, '..', 'dist', 'itkIntTypes.js'))
 const PixelTypes = require(path.resolve(__dirname, '..', 'dist', 'itkPixelTypes.js'))
 const readImageLocalFile = require(path.resolve(__dirname, '..', 'dist', 'itkreadImageLocalFile.js'))
-const itkConfig = require(path.resolve(__dirname, '..', 'dist', 'itkConfig.js'))
-itkConfig.imageIOsPath = path.resolve(__dirname, '..', 'dist', 'itkImageIOs')
 
 const testFilePath = path.resolve(__dirname, '..', 'build', 'ExternalData', 'test', 'Input', 'cthead1.png')
 


### PR DESCRIPTION
…gurable

With node, it can be configured as described in the node-config documentation:

  https://www.npmjs.com/package/config

With browserify, it can be configured by supplying a JSON file with something
like aliasify for 'config':

  https://github.com/benbria/aliasify

With webpack, it can also be configured by supplying a JSON file:

  https://github.com/lorenwest/node-config/wiki/Webpack-Usage