### PR TITLE
ci(npm): fix authentication with npm.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,7 @@ deployment:
     branch: release
     owner: InsightSoftwareConsortium
     commands:
+      - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
       - npm run semantic-release
 
   iodoc:


### PR DESCRIPTION
To address:

  All done
  npm ERR! Linux 3.13.0-119-generic
  npm ERR! argv "/opt/circleci/nodejs/v6.10.3/bin/node" "/opt/circleci/nodejs/v6.10.3/bin/npm" "publish"
  npm ERR! node v6.10.3
  npm ERR! npm  v3.10.10
  npm ERR! code ENEEDAUTH

  npm ERR! need auth auth required for publishing
  npm ERR! need auth You need to authorize this machine using `npm adduser`

According to: http://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules